### PR TITLE
First check-in with initial set of Java files for Spotify REST API client

### DIFF
--- a/src/dev/brianmiller/properties/Properties.java
+++ b/src/dev/brianmiller/properties/Properties.java
@@ -1,0 +1,84 @@
+package dev.brianmiller.properties;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Properties {
+
+    private static final String DEFAULT_PROPERTY_FILE_NAME = "properties.txt";
+    private static String propertyFileName = DEFAULT_PROPERTY_FILE_NAME;
+
+    private static final Map<String, String> properties = new HashMap<>();
+
+    private Properties() {
+    }
+
+    private static void readPropertiesFromFile(String fileName) {
+        if ((fileName == null) || (fileName.isBlank())) {
+            throw new IllegalArgumentException("Properties file name is null or empty string");
+        }
+        propertyFileName = fileName;
+        Path path = Path.of(propertyFileName);
+        if (Files.exists(path)) {
+            if (Files.isRegularFile(path)) {
+                try {
+                    List<String> lines = Files.readAllLines(path);
+                    for (String line : lines) {
+                        String separator = " ";
+                        if (line.contains("=")) {
+                            separator = "=";
+                        } else if (line.contains(":")) {
+                            separator = ":";
+                        }
+                        String[] parts = line.split(separator);
+                        if ((parts.length == 2) &&
+                                !(parts[0].isBlank()) &&
+                                !(parts[1].isBlank())) {
+                            properties.put(parts[0].toLowerCase().trim(),
+                                    parts[1].trim());
+                        }
+
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            } else {
+                throw new RuntimeException(
+                        new IOException("Not a regular file: " + fileName));
+            }
+        } else {
+            throw new RuntimeException(
+                    new FileNotFoundException("File does not exist: " + fileName));
+        }
+    }
+
+    public static String getValue(String propertyFileName, String property) {
+        if (property == null) {
+            throw new IllegalArgumentException("property name must not be null");
+        }
+        if (properties.isEmpty()) {
+            readPropertiesFromFile(propertyFileName);
+            if (properties.isEmpty()) {
+                System.err.println("Error: No property values found!");
+                return null; // TODO: throw exception ???
+            }
+        }
+        String key = property.toLowerCase().trim();
+        if (properties.containsKey(key)) {
+            return properties.get(key);
+        } else {
+            System.err.println("No property found: " + property);
+        }
+        return null;
+    }
+
+    public static String getValue(String property) {
+        return getValue(DEFAULT_PROPERTY_FILE_NAME, property);
+    }
+
+}

--- a/src/dev/brianmiller/restclient/RestClient.java
+++ b/src/dev/brianmiller/restclient/RestClient.java
@@ -1,0 +1,131 @@
+package dev.brianmiller.restclient;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+public class RestClient {
+
+    private final HttpClient httpClient;
+
+    public RestClient() {
+        httpClient = HttpClient.newHttpClient();
+    }
+
+    public String getAsString(String urlString) {
+
+        String result = "";
+
+        try {
+            URL url = new URL(urlString);
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .GET()
+                    .uri(url.toURI())
+                    // .header("User-Agent", "Chrome")
+                    .headers("Accept", "application/json") //, "Accept","text/html")
+                    .timeout(Duration.ofSeconds(30))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString()); //.ofLines());
+            if (response.statusCode() != HTTP_OK) {
+                result = "ERROR: " + response.statusCode();
+            } else {
+                result = response.body();
+            //response.body().collect(Collectors.joining());
+            }
+
+        } catch (IOException | URISyntaxException | InterruptedException e) {
+            e.printStackTrace(System.err);
+            return "ERROR: " + e;
+        }
+
+        return result;
+    }
+
+    public RestResponse get(String urlString, Map<String, String> httpHeaders) {
+        RestResponse restResponse = null;
+        try {
+            URL url = new URL(urlString);
+
+            var builder = HttpRequest.newBuilder()
+                    .GET()
+                    .uri(url.toURI())
+                    .timeout(Duration.ofSeconds(30));
+            for (Map.Entry<String, String> header : httpHeaders.entrySet()) {
+                builder.header(header.getKey(), header.getValue());
+                // System.out.println("Added header: " + header.getKey() + ": " + header.getValue());
+            }
+            HttpRequest request = builder.build();
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            restResponse = new RestResponse(response.statusCode(),
+                    response.body());
+            if (response.statusCode() != HTTP_OK) {
+                System.err.println(response.statusCode());
+                System.err.println(response.body());
+            }
+
+        } catch (URISyntaxException | IOException | InterruptedException e) {
+            e.printStackTrace(System.err);
+            // TODO: logging
+            // TODO: throw runtime exception ??
+        }
+        return restResponse;
+    }
+
+    public RestResponse post(String urlString, Map<String, String> httpHeaders, Map<String, String> dataKeyValuePairs) {
+
+        RestResponse restResponse = null;
+        StringBuilder bodySB = new StringBuilder();
+        for (Map.Entry<String, String> entry : dataKeyValuePairs.entrySet()) {
+            if (!bodySB.isEmpty()) {
+                bodySB.append("&");
+            }
+            bodySB.append(entry.getKey());
+            bodySB.append("=");
+            bodySB.append(entry.getValue());
+        }
+        String body = bodySB.toString();
+
+        try {
+            URL url = new URL(urlString);
+
+            var builder = HttpRequest.newBuilder()
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .uri(url.toURI())
+                    .timeout(Duration.ofSeconds(30));
+            for (Map.Entry<String, String> header : httpHeaders.entrySet()) {
+                builder.header(header.getKey(), header.getValue());
+                // System.out.println("Added header: " + header.getKey() + ": " + header.getValue());
+            }
+
+
+            HttpRequest request = builder.build();
+            HttpResponse<String> response = httpClient.send(request,
+                    HttpResponse.BodyHandlers.ofString());
+            restResponse = new RestResponse(response.statusCode(),
+                    response.body());
+            if (response.statusCode() != HTTP_OK) {
+                System.err.println(response.statusCode());
+                System.err.println(response.body());
+            }
+
+        } catch (URISyntaxException | IOException | InterruptedException e) {
+            e.printStackTrace(System.err);
+            // TODO: logging
+            // TODO: throw runtime exception ??
+        }
+
+        return restResponse;
+    }
+
+}

--- a/src/dev/brianmiller/restclient/RestResponse.java
+++ b/src/dev/brianmiller/restclient/RestResponse.java
@@ -1,0 +1,41 @@
+package dev.brianmiller.restclient;
+
+public class RestResponse {
+
+    private final int code;
+    private final String reason;
+    private final String body;
+
+    public RestResponse(int code, String reason, String body) {
+        this.code = code;
+        this.reason = reason;
+        this.body = body;
+    }
+
+    public RestResponse(int code, String body) {
+        this.code = code;
+        this.reason = null;
+        this.body = body;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    @Override
+    public String toString() {
+        return "RestResponse{" +
+                "code=" + code +
+                ", reason='" + reason + '\'' +
+                ", body='" + body + '\'' +
+                '}';
+    }
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyAccessTokenResponse.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyAccessTokenResponse.java
@@ -1,0 +1,5 @@
+package dev.brianmiller.restclient.spotify;
+
+public record SpotifyAccessTokenResponse(String access_token, String token_type,
+        int expires_in) {
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyAlbum.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyAlbum.java
@@ -1,0 +1,33 @@
+package dev.brianmiller.restclient.spotify;
+
+import java.util.Objects;
+
+public record SpotifyAlbum(
+        String album_type,
+        int total_tracks,
+        String[] available_markets,
+        // SpotifyExternalUrls external_urls,
+        String href,
+        String id,
+        // SpotifyImage[] images,
+        String name,
+        String releaseDate,
+        String releaseDatePrecision,
+        // restrictions
+        String type,
+        String uri,
+        SpotifyArtist[] artists
+) {
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof SpotifyAlbum that)) return false;
+        return Objects.equals(id, that.id) && Objects.equals(name, that.name) && Objects.equals(type, that.type) && Objects.equals(album_type, that.album_type) && Objects.equals(releaseDate, that.releaseDate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(album_type, id, name, releaseDate, type);
+    }
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyArtist.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyArtist.java
@@ -1,0 +1,11 @@
+package dev.brianmiller.restclient.spotify;
+
+public record SpotifyArtist(
+        // external_urls
+        String href,
+        String id,
+        String name,
+        String type,
+        String uri
+) {
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyClient.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyClient.java
@@ -1,0 +1,197 @@
+package dev.brianmiller.restclient.spotify;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+
+import dev.brianmiller.properties.Properties;
+
+import dev.brianmiller.restclient.RestClient;
+import dev.brianmiller.restclient.RestResponse;
+
+import static java.net.HttpURLConnection.HTTP_OK;
+
+/**
+ *
+ */
+public class SpotifyClient {
+
+    private final static String REQUEST_ACCESS_TOKEN_ENDPOINT_URL =
+            "https://accounts.spotify.com/api/token";
+
+    private final static String PLAYLISTS_URL_PREFIX = "https://api.spotify.com/v1/playlists/";
+    private final static String PLAYLIST_TRACKS_URL_SUFFIX = "/tracks";
+
+    private final static String HEADER_ACCEPT_KEY   = "Accept";
+    private final static String HEADER_ACCEPT_VALUE = "application/json";
+
+    private final static String HEADER_CONTENT_TYPE_KEY = "Content-Type";
+    private final static String HEADER_CONTENT_TYPE_VALUE = "application/x-www-form-urlencoded";
+
+    private final static String HEADER_AUTHORIZATION_KEY = "Authorization";
+    private final static String HEADER_AUTHORIZATION_VALUE_PREFIX = "Bearer ";
+
+    private final static String DATA_GRANT_TYPE_KEY = "grant_type";
+    private final static String DATA_GRANT_TYPE_VALUE_CLIENT_CREDENTIALS = "client_credentials";
+
+    private final static String DATA_CLIENT_ID_KEY = "client_id";
+    private final static String DATA_CLIENT_SECRET_KEY = "client_secret";
+
+    private final static String PROPERTY_KEY_CLIENT_ID = "spotify_client_id";
+    private final static String PROPERTY_KEY_CLIENT_SECRET = "spotify_client_secret";
+
+    private static String clientID;
+    private static String clientSecret;
+    private static String accessToken;
+    private static LocalDateTime accessTokenExpiration;
+
+    static {
+        clientID = Properties.getValue(PROPERTY_KEY_CLIENT_ID);
+        clientSecret = Properties.getValue(PROPERTY_KEY_CLIENT_SECRET);
+        accessToken = null;
+        accessTokenExpiration = null;
+    }
+
+    private RestClient restClient;
+
+    public SpotifyClient() {
+        this.restClient = new RestClient();
+    }
+
+    private String getAccessToken() {
+        // TODO: reverse if/else
+        if (accessToken == null || accessTokenExpiration == null ||
+            LocalDateTime.now().isAfter(accessTokenExpiration)) {
+
+            Map<String, String> headerMap = new HashMap<>();
+            headerMap.put(HEADER_CONTENT_TYPE_KEY, HEADER_CONTENT_TYPE_VALUE);
+
+            Map<String, String> dataMap = new HashMap<>();
+            dataMap.put(DATA_GRANT_TYPE_KEY, DATA_GRANT_TYPE_VALUE_CLIENT_CREDENTIALS);
+            dataMap.put(DATA_CLIENT_ID_KEY, clientID);
+            dataMap.put(DATA_CLIENT_SECRET_KEY, clientSecret);
+
+            RestResponse restResponseRequestAccessToken =
+                    restClient.post(REQUEST_ACCESS_TOKEN_ENDPOINT_URL,
+                            headerMap, dataMap);
+
+            if ((restResponseRequestAccessToken != null) &&
+                    (restResponseRequestAccessToken.getCode() == HTTP_OK) &&
+                    (restResponseRequestAccessToken.getBody() != null)) {
+
+                Gson gson = new Gson();
+                try {
+                    SpotifyAccessTokenResponse spotifyAccessTokenResponse =
+                            gson.fromJson(restResponseRequestAccessToken.getBody(),
+                                    SpotifyAccessTokenResponse.class);
+                    if ((spotifyAccessTokenResponse != null) &&
+                            (spotifyAccessTokenResponse.access_token() != null)) {
+                        accessToken = spotifyAccessTokenResponse.access_token();
+                        accessTokenExpiration = LocalDateTime.now().plusSeconds(
+                                spotifyAccessTokenResponse.expires_in()
+                        );
+                        return accessToken;
+                    }
+                } catch (JsonSyntaxException ex) {
+                    System.err.println("Failed to parse access token response from Spotify");
+                    ex.printStackTrace(System.err);
+                }
+            }
+
+        } else {
+            return accessToken;
+        }
+        return null;
+    }
+
+    /**
+     *
+     * @param playlistURL fully-qualified URL
+     * @return
+     */
+    public List<SpotifyAlbum> getListAlbumsInPlaylist(String playlistURL) {
+        List<SpotifyAlbum> albumsList = new ArrayList<>();
+
+        String accessToken = getAccessToken();
+        System.out.println("accessToken: " + accessToken);
+
+        String url = playlistURL.trim();
+        if (!url.endsWith("tracks") && !url.endsWith("tracks/")) {
+            if (url.endsWith("/")) {
+                url = url + "tracks";
+            } else {
+                url = url + "/tracks";
+            }
+        }
+
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(HEADER_ACCEPT_KEY, HEADER_ACCEPT_VALUE);
+        headerMap.put(HEADER_AUTHORIZATION_KEY, HEADER_AUTHORIZATION_VALUE_PREFIX + accessToken);
+
+        Gson gson = new Gson();
+        RestResponse restResponse = restClient.get(url, headerMap);
+        if (restResponse == null) {
+            System.err.println("null response to " + url);
+        } else {
+            // System.out.println(url);
+            // System.out.println("Response Code: " + restResponse.getCode());
+            // System.out.println("Response Body: " + restResponse.getBody());
+        }
+        boolean readNextPage = true;
+        while (readNextPage && (restResponse != null) && (restResponse.getCode() == HTTP_OK) &&
+                (restResponse.getBody() != null)) {
+
+            try {
+                SpotifyPlaylistTracksResponse spotResponse =
+                        gson.fromJson(restResponse.getBody(), SpotifyPlaylistTracksResponse.class);
+
+                if (spotResponse == null) {
+                    readNextPage = false;
+                } else {
+
+                    var items = spotResponse.items();
+                    if (items != null) {
+                        for (var item : items) {
+                            var track = item.track();
+                            if (track != null) {
+                                var album = track.album();
+                                if (album != null) {
+                                    if (!albumsList.contains(album)) {
+                                        albumsList.add(album);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    String nextURL = spotResponse.next();
+                    if ((nextURL == null) || nextURL.isBlank()) {
+                        readNextPage = false;
+                    } else {
+                        restResponse = restClient.get(nextURL, headerMap);
+                        if (restResponse == null) {
+                            //System.err.println("null response to " + url);
+                        } else {
+                            //System.out.println(url);
+                            //System.out.println("Response Code: " + restResponse.getCode());
+                        }
+
+                    }
+                }
+
+            } catch (Exception ex) {
+                //
+                readNextPage = false;
+            }
+        }
+
+
+        return albumsList;
+    }
+
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyPlaylistContentItem.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyPlaylistContentItem.java
@@ -1,0 +1,7 @@
+package dev.brianmiller.restclient.spotify;
+
+public record SpotifyPlaylistContentItem(
+        String added_at,
+        boolean is_local,
+        SpotifyTrack track) {
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyPlaylistTracksResponse.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyPlaylistTracksResponse.java
@@ -1,0 +1,11 @@
+package dev.brianmiller.restclient.spotify;
+
+public record SpotifyPlaylistTracksResponse(
+        String href,
+        int limit,
+        String next,
+        int offset,
+        String previous,
+        int total,
+        SpotifyPlaylistContentItem[] items) {
+}

--- a/src/dev/brianmiller/restclient/spotify/SpotifyTrack.java
+++ b/src/dev/brianmiller/restclient/spotify/SpotifyTrack.java
@@ -1,0 +1,27 @@
+package dev.brianmiller.restclient.spotify;
+
+public record SpotifyTrack(
+    SpotifyAlbum album,
+    SpotifyArtist[] artists,
+    String[] available_markets,
+    int disc_number,
+    int duration_ms,
+    boolean explicit,
+    // external_ids
+    // external_urls
+    String href,
+    String id,
+    boolean is_playable,
+    // linked_from
+    // restrictions
+    String name,
+    int popularity,
+    String preview_url,
+    int track_number,
+    String type,
+    String uri,
+    boolean is_local
+) {
+
+
+}


### PR DESCRIPTION
First check-in with initial set of Java files for Spotify REST API client

Initial focus is on getting a list of albums included in a playlist. In order to do that, I first read the developer's Spotify Client ID and Client Secret from a properties.txt file (not included in this check-in). Those are then used to get an Access Token from Spotify. The Access Token is in turn used for other Spotify REST APIs such as getting a list of items contained in a playlist. Note that the playlist URL should be of the form
https://api.spotify.com/v1/playlists/{UNIQUE_ID}/tracks and NOT
https://open.spotify.com/playlist/{UNIQUE_ID}
If you use the latter, it will return HTML instead of the desired JSON formatted data, so api.spotify.com
is needed to get formatted data and parse it to Java objects